### PR TITLE
Allow using custom login backend

### DIFF
--- a/ninja_auth/api.py
+++ b/ninja_auth/api.py
@@ -27,7 +27,8 @@ from .schema import (
 
 router = Router()
 _TGS = ['Django Ninja Auth']
-_LOGIN_BACKEND = 'django.contrib.auth.backends.ModelBackend'
+_LOGIN_BACKEND = getattr(settings, "AUTHENTICATION_BACKENDS", 
+                        'django.contrib.auth.backends.ModelBackend')
 
 
 @router.post('/', tags=_TGS, response={200: UserOut, 403: None}, auth=None)


### PR DESCRIPTION
Use the custom login backend specified in Django's settings.py (`AUTHENTICATION_BACKENDS`) if available. 

Please refer to: https://docs.djangoproject.com/en/4.0/topics/auth/customizing/ 